### PR TITLE
rag-agent was in coordinator-agent intagrated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 .env.*
+Dataset/
+__pycache__/
+persist_store/

--- a/rag_no_img.py
+++ b/rag_no_img.py
@@ -183,5 +183,11 @@ class RAGAgent:
             "documents": results["documents"],
             "metadatas": results["metadatas"]
         }
-
+#----------------------------------------------------------------------------------------------------------------------------
+def generateAnswerTool(question):
+    print("Generate answer tool test")
+    agent=RAGAgent()
+    agent.indexPDF()
+    return agent.generate_answer(question)
+    
 


### PR DESCRIPTION
## Summary by Sourcery

Integrate a RAG-based investor report agent into the coordinator, replacing the analytics agent with a specialized RAG agent for answering finance questions from SEC 10-Q/K reports, and configure environment variables for LangChain tracing.

New Features:
- Introduce generateAnswerTool wrapper and RAGAgent integration for question answering.
- Load environment variables and enable LangChain tracing for the RAG agent.
- Define a rag Tool and create rag_agent using a React agent for finance Q&A from SEC reports.

Enhancements:
- Update coordinator_handle and supervisor configuration to route user queries to rag_agent instead of the analytics agent.
- Adjust test script to send sample questions to the new rag_agent.